### PR TITLE
Make the external_auth attribute required

### DIFF
--- a/internal/provider.go
+++ b/internal/provider.go
@@ -47,7 +47,7 @@ func (b BoxerProvider) Schema(_ context.Context, _ provider.SchemaRequest, respo
 			},
 			"external_auth": schema.SingleNestedAttribute{
 				Description: "Configuration for external authentication",
-				Optional:    true,
+				Optional:    false,
 				Attributes: map[string]schema.Attribute{
 					"security_token": schema.StringAttribute{
 						Description: "An external security token to use for Boxer Issuer API calls. " +


### PR DESCRIPTION
Follow-up for #36

THe `external_auth` attribute should be marked as required


## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.