### PR TITLE
Fix provider behavior and update Terraform configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,9 @@ pkg/openapi.json*
 
 # Integration tsts dependency charts
 /integration_tests/helm/setup/charts/*.tgz
+
+# Terraform state files and directories in the examples directory
+/examples/**/.terraform/
+/examples/**/.terraform.lock.hcl
+/examples/**/terraform.tfstate
+/examples/**/terraform.tfstate.backup

--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
 # terraform-provider-boxer
 
 A Terraform provider for managing [Boxer](https://github.com/SneaksAndData/boxer-issuer) resources.
+
+## Authentication to the Keycloak server for the manual testing of the provider
+
+```shell
+$ curl \
+  -d "client_id=test_client" \
+  -d "client_secret=test_client_secret" \
+  -d "username=test_root" \
+  -d "password=test-root-password" \
+  -d "grant_type=password" \
+  "http://localhost:5555/auth/realms/master/protocol/openid-connect/token"
+```

--- a/examples/resources/issuer_cedar_schema/main.tf
+++ b/examples/resources/issuer_cedar_schema/main.tf
@@ -7,8 +7,14 @@ terraform {
 }
 
 provider "boxer" {
-  issuer_host    = "http://localhost:8888/"
-  validator_host = "http://localhost:8888/"
+  external_auth = {
+    security_token = "<insert-token-here>"
+    identity_provider_id = "keycloak"
+    internal_token_provider_endpoint = "http://localhost:5555/issuer"
+  }
+
+  issuer_host    = "http://localhost:5555/issuer"
+  validator_host = "http://localhost:5555/validator"
 }
 
 resource "boxer_issuer_cedar_schema" "example" {
@@ -56,5 +62,5 @@ EOT
 }
 
 output "test" {
-  value = boxer_cedar_schema.example
+  value = boxer_issuer_cedar_schema.example
 }

--- a/internal/issuer/resource_cedar_schema.go
+++ b/internal/issuer/resource_cedar_schema.go
@@ -3,6 +3,7 @@ package issuer
 import (
 	"context"
 	"fmt"
+
 	cedarschema "github.com/cedar-policy/cedar-go/x/exp/schema"
 	"github.com/go-faster/jx"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -122,7 +123,13 @@ func (resource *cedarSchemaResource) Read(ctx context.Context, request resource.
 		common.GenerateError(&response.Diagnostics, "Reading", "Cedar Schema", err)
 		return
 	}
-	err = saveNewState(ctx, stateModel.ID.ValueString(), stateModel.DataJson.ValueString(), stateModel.ValidateDataJson.ValueBool(), &response.State, &response.Diagnostics)
+	err = saveNewState(ctx,
+		stateModel.ID.ValueString(),
+		stateModel.DataJson.ValueString(),
+		stateModel.ValidateDataJson.ValueBool(),
+		&response.State,
+		&response.Diagnostics)
+
 	// If we can't save the stateModel, we can't proceed with the update.
 	// so we return early.
 	// The error will be handled by the framework and returned to the user.
@@ -150,13 +157,20 @@ func (resource *cedarSchemaResource) Update(ctx context.Context, request resourc
 		return
 	}
 
-	err = resource.issuerClient.PostSchema(ctx, jx.Raw(planModel.DataJson.ValueString()), issuerClient.PostSchemaParams{ID: planModel.ID.ValueString()})
+	boxerRequest := issuerClient.PostSchemaParams{ID: planModel.ID.ValueString()}
+	err = resource.issuerClient.PostSchema(ctx, jx.Raw(planModel.DataJson.ValueString()), boxerRequest)
 	if err != nil { // coverage-ignore
 		common.GenerateError(&response.Diagnostics, "Updating", "Cedar Schema", err)
 		return
 	}
 
-	err = saveNewState(ctx, stateModel.ID.ValueString(), stateModel.DataJson.ValueString(), stateModel.ValidateDataJson.ValueBool(), &response.State, &response.Diagnostics)
+	err = saveNewState(ctx,
+		planModel.ID.ValueString(),
+		planModel.DataJson.ValueString(),
+		planModel.ValidateDataJson.ValueBool(),
+		&response.State,
+		&response.Diagnostics)
+
 	// If we can't save the stateModel, we can't proceed with the update.
 	// so we return early.
 	// The error will be handled by the framework and returned to the user.

--- a/internal/validator/resource_cedar_schema.go
+++ b/internal/validator/resource_cedar_schema.go
@@ -3,6 +3,7 @@ package validator
 import (
 	"context"
 	"fmt"
+
 	cedarschema "github.com/cedar-policy/cedar-go/x/exp/schema"
 	"github.com/go-faster/jx"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -149,13 +150,20 @@ func (resource *cedarSchemaResource) Update(ctx context.Context, request resourc
 		return
 	}
 
-	err = resource.validatorClient.PostSchema(ctx, jx.Raw(planModel.DataJson.ValueString()), validatorClient.PostSchemaParams{ID: planModel.ID.ValueString()})
+	boxerRequest := validatorClient.PostSchemaParams{ID: planModel.ID.ValueString()}
+	err = resource.validatorClient.PostSchema(ctx, jx.Raw(planModel.DataJson.ValueString()), boxerRequest)
 	if err != nil { // coverage-ignore
 		common.GenerateError(&response.Diagnostics, "Updating", "Cedar Schema", err)
 		return
 	}
 
-	err = saveNewState(ctx, stateModel.ID.ValueString(), planModel.DataJson.ValueString(), planModel.ValidateDataJson.ValueBool(), &response.State, &response.Diagnostics)
+	err = saveNewState(ctx,
+		planModel.ID.ValueString(),
+		planModel.DataJson.ValueString(),
+		planModel.ValidateDataJson.ValueBool(),
+		&response.State,
+		&response.Diagnostics)
+
 	// If we can't save the stateModel, we can't proceed with the update.
 	// so we return early.
 	// The error will be handled by the framework and returned to the user.


### PR DESCRIPTION
## Scope

Implemented:
This pull request fixes the behavior when the provider does not use the state model from plan to save new state, but uses the old state to update the state model, which lead to an `inconsistent state` error.

Additional changes:
- Adjusted provider configuration to use the correct endpoints and added external authentication parameters.
- Updated output value to reference the correct resource.
- Enhanced .gitignore to exclude Terraform state files in examples.
- Improved code readability with formatting changes in resource handling.

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [x] Review requested on `latest` commit.
--- 
- [ ] Documentation updated (if applicable).
> [!NOTE]
> Run the commands listed in `tools/tools.go` to update generated documentation files.
--- 
- [ ] This commit should be released in the next minor release.
- [x] This commit should be released in the next patch release.
- [ ] This commit should NOT be released (e.g. documentation changes).
---
- [ ] This commit contains breaking changes.
> [!WARNING]
> If you check this box, please ensure that you follow the [breaking change process](https://developer.hashicorp.com/terraform/plugin/sdkv2/best-practices/deprecations)
